### PR TITLE
Fix file transfer client stream close

### DIFF
--- a/Projects/4_Server_for_file_transfers/src/com/client/Client.java
+++ b/Projects/4_Server_for_file_transfers/src/com/client/Client.java
@@ -42,7 +42,7 @@ public class Client {
                     File arquivo = file.getSelectedFile();
                     sendFile(arquivo.getPath());
                     dataInputStream.close();
-                    dataInputStream.close();
+                    dataOutputStream.close();
                     socket.close();
                 }
             } catch (Exception e) {


### PR DESCRIPTION
## Summary
- fix double-closing of input stream in Java file transfer client

## Testing
- `javac Projects/4_Server_for_file_transfers/src/com/client/Client.java`
- `javac Projects/4_Server_for_file_transfers/src/com/server/Server.java`


------
https://chatgpt.com/codex/tasks/task_e_687b438dc6e88322ad05d70aa8a8c021